### PR TITLE
Add PageShot — free screenshot and webpage capture API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 ### APIs
 
 * [LetsValidate](https://github.com/letsvalidate/api) - Free fast real-time website screenshot API
+* [PageShot](https://pageshot.site) - Free screenshot and webpage capture REST API powered by Playwright. Supports full-page screenshots, custom viewports, and multiple output formats. No API key required.
 * [SnapAPI](https://snapapi.pics) - REST API for screenshots, PDFs, video recording, and web data extraction. Supports device emulation, dark mode, cookie banner blocking, and full-page captures. Free tier available.
 
 ### Device Mockups


### PR DESCRIPTION
## What

Adds [PageShot](https://pageshot.site) to the **APIs** section, placed alphabetically between LetsValidate and SnapAPI.

## About PageShot

PageShot is a free REST API for capturing website screenshots, powered by Playwright. Supports full-page screenshots, custom viewports, and multiple output formats. No API key required, free forever.

- Website: https://pageshot.site
- API docs: https://pageshot.site/docs

Follows the contribution guidelines format: `[Name](link) - description.`