### PR TITLE
Add Moonshot to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 * [Am I Responsive](http://ami.responsivedesign.is/) - Take all devices(Phone, Tablet, Laptop, Desktop) screenshots in 1 image.
 * [Realshots](https://www.realshots.net/) - Realistic App Screenshots for Free.
 * [Mockup Photos](https://mockup.photos) - Free & Premium Mockup Photos with more than 510+ unique mockups.
+* [Moonshot](https://ameeramer.github.io/) - Wrap screenshots in macOS, browser or phone frames on gradient backdrops and export retina PNGs. Runs entirely in the browser with no signup and nothing uploaded. Free with a Pro tier.
 
 ### APIs
 


### PR DESCRIPTION
Adds Moonshot to the Websites section (online tools). It frames screenshots in macOS/browser/phone frames on gradient backdrops and exports retina PNGs — fully client-side, no signup, nothing uploaded. Follows the contributing format `[Name](link) - description.`; searched for duplicates first (none). Free with an optional Pro tier.