### PR TITLE
Add Latchshot to screenshot APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 
 ### APIs
 
+* [Latchshot](https://latchshot.fly.dev) - Guarded screenshot and PDF REST API for public URLs. Supports PNG, JPEG, bounded full-page capture, custom viewports, dark mode, and a hosted MCP server. Recurring free tier; Bearer API key required.
 * [LetsValidate](https://github.com/letsvalidate/api) - Free fast real-time website screenshot API
 * [PageShot](https://pageshot.site) - Free screenshot and webpage capture REST API powered by Playwright. Supports full-page screenshots, custom viewports, and multiple output formats. No API key required.
 * [Site-Shot](https://www.site-shot.com/) - Website screenshot API with a free no-signup online tool and an official MCP server (npx -y site-shot-mcp). Real Chromium, full-page capture, country proxies (geo/language/timezone), and automatic ad & cookie-banner removal. From $5/mo.


### PR DESCRIPTION
## Summary

Add Latchshot to the APIs section using the list's required one-line format.

Latchshot is a hosted screenshot and PDF REST API for public URLs. The entry states its current formats and controls, recurring free tier, required Bearer authentication, and hosted MCP surface without claiming unsupported browser automation features.

Disclosure: I maintain Latchshot.

## Validation

- `https://latchshot.fly.dev/` returns HTTP 200.
- The live OpenAPI 3.1 document exposes `POST /v1/render`.
- `git diff --check` passes.
- `awesome-lint` reports no error on the added line; its remaining findings are pre-existing list/repository metadata issues.

