### PR TITLE
Add SnapShot API to APIs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 * [PageShot](https://pageshot.site) - Free screenshot and webpage capture REST API powered by Playwright. Supports full-page screenshots, custom viewports, and multiple output formats. No API key required.
 * [Site-Shot](https://www.site-shot.com/) - Website screenshot API with a free no-signup online tool and an official MCP server (npx -y site-shot-mcp). Real Chromium, full-page capture, country proxies (geo/language/timezone), and automatic ad & cookie-banner removal. From $5/mo.
 * [SnapAPI](https://snapapi.pics) - REST API for screenshots, PDFs, video recording, and web data extraction. Supports device emulation, dark mode, cookie banner blocking, and full-page captures. Free tier available.
+* [SnapShot API](https://snapshot-api-production-1374.up.railway.app) - Screenshot API with instant key via curl (no signup, no email). Full-page PNG captures, referral bonuses, and interactive playground. Open source. Free tier: 100/mo.
 
 ### Device Mockups
 


### PR DESCRIPTION
Adds [SnapShot API](https://snapshot-api-production-1374.up.railway.app) to the APIs section — a screenshot API with instant key via curl (no signup), full-page PNG captures, referral bonuses, and an interactive playground. Open source on [GitHub](https://github.com/bakasa/snapshot-api).