### PR TITLE
Add Background to Screenshot to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 * [Realshots](https://www.realshots.net/) - Realistic App Screenshots for Free.
 * [Mockup Photos](https://mockup.photos) - Free & Premium Mockup Photos with more than 510+ unique mockups.
 * [Moonshot](https://ameeramer.github.io/) - Wrap screenshots in macOS, browser or phone frames on gradient backdrops and export retina PNGs. Runs entirely in the browser with no signup and nothing uploaded. Free with a Pro tier.
+* [Add Background to Screenshot](https://alltoolsverse.com/tools/add-background-to-screenshot/) - Polish screenshots with gradient or solid backgrounds, adjustable padding, rounded corners, and shadows, then export a PNG. Runs entirely in the browser with no signup and nothing uploaded.
 
 ### APIs
 


### PR DESCRIPTION
## What

Adds [Add Background to Screenshot](https://alltoolsverse.com/tools/add-background-to-screenshot/) to the **Websites** section.

## Why it fits

The tool polishes screenshots with gradient or solid backgrounds, adjustable padding, rounded corners, and shadows, then exports a PNG. It closely matches the section scope and the recently accepted Moonshot entry.

## Validation

- Verified that the live page exposes JPG, PNG, and WebP upload support plus PNG download.
- Confirmed that the tool runs client-side with no signup.
- Searched the current list and previous pull requests for duplicates.
- Kept the change to one README addition.

## Disclosure

I am affiliated with All Tools Verse. Codex assisted with repository research, wording, and submission. I reviewed the contribution guidelines and the live tool before opening this pull request.